### PR TITLE
fix the bug with the encoding when running it on Windows Machine

### DIFF
--- a/src/aurore/proc_rst.py
+++ b/src/aurore/proc_rst.py
@@ -9,7 +9,7 @@ from .utils import norm_join
 report_level = docutils.utils.Reporter.SEVERE_LEVEL + 1
 
 def rst_to_xml(filename):
-    with open(filename,"r") as f:
+    with open(filename,"r", encoding="utf-8") as f:
         doctree = publish_doctree(
                 f.read(),
                 settings_overrides={'report_level':report_level}


### PR DESCRIPTION
When running on windows, python's default encoding in opening a text file is cp1252. While it readme file (when making r2d) in my machine is (window, making using git bash) is in UTF-8. I think it's a better practice if we specify the encoding to avoid such platform dependencies.